### PR TITLE
Rearrange build

### DIFF
--- a/zagreus-server/src/template/event.rs
+++ b/zagreus-server/src/template/event.rs
@@ -1,5 +1,5 @@
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "tag", content = "payload")]
 pub enum TemplateEvent {
-    TemplateReloaded { template_name: String},
+    TemplateReloaded { template_name: String },
 }


### PR DESCRIPTION
- Run rustfmt check first to detect "wrong" formatting
- Move building the release artifact to the very end of the build process. That way the build should always fail as early as possible (if a test or linting error occurs)