### PR TITLE
Cleanup logging

### DIFF
--- a/zagreus-generator/src/build/mod.rs
+++ b/zagreus-generator/src/build/mod.rs
@@ -31,8 +31,6 @@ pub fn build_template(
     build_folder: &Path,
     template_config: &TemplateConfig,
 ) -> Result<(), ZagreusError> {
-    info!("Building template {}...", &template_config.name);
-
     if !build_folder.exists() {
         if let Err(err) = std::fs::create_dir(build_folder) {
             return error_with_message("Could not create build folder", err);
@@ -111,8 +109,6 @@ pub fn build_template(
     let assets_folder = PathBuf::from(ASSETS_FOLDER_NAME);
     let packed_file_path = get_zipped_template_file_path(build_folder);
     zip::pack_template(&packed_file_path, &build_files, &assets_folder).unwrap();
-
-    info!("Finished building template {}.", &template_config.name);
 
     Ok(())
 }

--- a/zagreus-generator/src/build/svg.rs
+++ b/zagreus-generator/src/build/svg.rs
@@ -33,13 +33,10 @@ pub fn process_svg(
                     }
                 }
 
-                match transform_event(&evt) {
-                    Some(transformed_event) => {
-                        if let Err(err) = processed_template_writer.write(transformed_event) {
-                            error!("Could not write event to output SVG file: {}.", err);
-                        }
+                if let Some(transformed_event) = transform_event(&evt) {
+                    if let Err(err) = processed_template_writer.write(transformed_event) {
+                        error!("Could not write event to output SVG file: {}.", err);
                     }
-                    None => warn!("Could not transform event, it is skipped {:?}", evt),
                 }
             }
             Err(err) => {
@@ -55,6 +52,7 @@ pub fn process_svg(
 fn transform_event(event: &ReaderEvent) -> Option<WriterEvent> {
     match event {
         ReaderEvent::StartDocument { .. } => None,
+        ReaderEvent::EndDocument => None,
         ReaderEvent::StartElement {
             name,
             attributes,

--- a/zagreus-generator/src/jobs.rs
+++ b/zagreus-generator/src/jobs.rs
@@ -40,6 +40,7 @@ fn build_once(
     build_dir: &Path,
     upload: bool,
 ) -> Result<(), ZagreusError> {
+    info!("Building template {}...", &template_config.name);
     if let Err(error) = build::build_template(build_dir, &template_config) {
         return error_with_message(
             &format!("Could not build template {}", &template_config.name),


### PR DESCRIPTION
- Don't log warnings for elements that are left out
- Log only once per build (start + finish)