### PR TITLE
Remember generator version with which the template was built

### DIFF
--- a/zagreus-generator/src/build/mod.rs
+++ b/zagreus-generator/src/build/mod.rs
@@ -26,6 +26,7 @@ const HTML_FILE_NAME: &str = "index.html";
 const ELEMENTS_OUTPUT_FILE_NAME: &str = "elements.json";
 const TEMPLATE_CONFIG_OUTPUT_FILE_NAME: &str = "template.json";
 const ANIMATION_CONFIG_OUTPUT_FILE_NAME: &str = "animations.json";
+const META_INFO_OUTPUT_FILE_NAME: &str = "meta.json";
 
 pub fn build_template(
     build_folder: &Path,
@@ -36,6 +37,9 @@ pub fn build_template(
             return error_with_message("Could not create build folder", err);
         }
     }
+
+    // Create the meta data file.
+    crate::data::create_meta_file(build_folder, META_INFO_OUTPUT_FILE_NAME)?;
 
     let input_template_file_path = Path::new(INPUT_SVG_FILE_NAME);
     let processed_template_file_path = build_folder.join(PROCESSED_SVG_FILE_NAME);

--- a/zagreus-generator/src/main.rs
+++ b/zagreus-generator/src/main.rs
@@ -19,6 +19,7 @@ mod new;
 mod upload;
 
 const TEMPLATE_CONFIG_FILE_NAME: &str = "zagreus-template.yaml";
+const ZAGREUS_GENERATOR_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn main() {
     let command = cli::get_command();


### PR DESCRIPTION
* Extract package version at compile time, provided as an envvar by Cargo (compilation fails if not present, i.e. if not compiled through Cargo)
* During build, create a new file `meta.json` in the build dir
* Add a field `zagreusGeneratorVersion` to `meta.json`, the value of which is taken from the package version injected by Cargo