### PR TITLE
Recursively list files in assets directory

### DIFF
--- a/e2e-test/cypress/integration/test.ts
+++ b/e2e-test/cypress/integration/test.ts
@@ -64,7 +64,11 @@ describe('E2E test', () => {
 
                 cy.request('/api/template/e2e-template/asset').then(response => {
                     let assets = response.body;
-                    expect(assets).to.deep.equal(['dog.svg', 'dragon.png', 'main.css']);
+                    expect(assets).to.deep.equal([
+                        {name: 'main.css'},
+                        {name: 'dragon.png'},
+                        {name: 'dog.svg'},
+                    ]);
                 });
             });
         })

--- a/e2e-test/cypress/integration/test.ts
+++ b/e2e-test/cypress/integration/test.ts
@@ -64,11 +64,10 @@ describe('E2E test', () => {
 
                 cy.request('/api/template/e2e-template/asset').then(response => {
                     let assets = response.body;
-                    expect(assets).to.deep.equal([
-                        {name: 'main.css'},
-                        {name: 'dragon.png'},
-                        {name: 'dog.svg'},
-                    ]);
+                    expect(assets.length).to.equal(3);
+                    expect(assets).to.deep.contain({name: 'main.css'});
+                    expect(assets).to.deep.contain({name: 'dog.svg'});
+                    expect(assets).to.deep.contain({name: 'dragon.png'});
                 });
             });
         })

--- a/zagreus-server/src/endpoint/asset.rs
+++ b/zagreus-server/src/endpoint/asset.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fs::{DirEntry, ReadDir};
 use std::path::{Path, PathBuf};
@@ -53,28 +52,31 @@ pub(crate) async fn get_asset_filenames(
 
 #[derive(Serialize)]
 #[serde(untagged)]
-enum DirEntryType {
-    File, // TODO: Deserialize to empty array.
-    Dir(DirEntries),
+enum DirEntryNode {
+    File {
+        name: String,
+    },
+    Dir {
+        name: String,
+        children: Vec<DirEntryNode>,
+    },
 }
 
-type DirEntries = HashMap<String, DirEntryType>;
-
-fn traverse(files: ReadDir) -> DirEntries {
-    // TODO: Is there a more elegant way to use streams only, instead of keeping the map outside?
-    let mut entry_map = HashMap::new();
-    files.filter_map(|entry| entry.ok()).for_each(|entry| {
-        let path = entry.path();
-        let name = get_file_name(entry).unwrap(); // TODO: Don't use unwrap.
-
-        let child_node = match path.is_file() {
-            true => DirEntryType::File,
-            false => DirEntryType::Dir(traverse(std::fs::read_dir(path).unwrap())), // TODO: Don't use unwrap.
-        };
-
-        entry_map.insert(name, child_node);
-    });
-    entry_map
+fn traverse(files: ReadDir) -> Vec<DirEntryNode> {
+    files
+        .filter_map(|entry| entry.ok())
+        .map(|entry| {
+            let path = entry.path();
+            let name = get_file_name(entry).unwrap(); // TODO: Don't use unwrap.
+            match path.is_file() {
+                true => DirEntryNode::File { name },
+                false => DirEntryNode::Dir {
+                    name,
+                    children: traverse(std::fs::read_dir(path).unwrap()),
+                }, // TODO: Don't use unwrap.
+            }
+        })
+        .collect()
 }
 
 fn get_file_name(entry: DirEntry) -> Result<String, OsString> {

--- a/zagreus-server/src/endpoint/asset.rs
+++ b/zagreus-server/src/endpoint/asset.rs
@@ -1,4 +1,3 @@
-use std::fs::DirEntry;
 use std::path::{Path, PathBuf};
 
 use axum::body::Bytes;
@@ -9,6 +8,7 @@ use axum::Json;
 use serde_json::json;
 
 use crate::error::ZagreusError;
+use crate::fs;
 
 pub const ASSETS_FOLDER_NAME: &str = "assets";
 
@@ -27,7 +27,7 @@ pub(crate) async fn get_asset_filenames(
     templates_data_folder.push(ASSETS_FOLDER_NAME);
 
     let template_assets_folder = templates_data_folder;
-    let traversal_result = traverse(&template_assets_folder);
+    let traversal_result = fs::util::traverse(&template_assets_folder);
 
     match traversal_result {
         Ok(entries) => (StatusCode::OK, Json(json!(entries))),
@@ -42,49 +42,6 @@ pub(crate) async fn get_asset_filenames(
                 Json(json!("Could not read template assets.")),
             )
         }
-    }
-}
-
-// TODO: Consider factoring out into a file helper module.
-
-#[derive(Serialize)]
-#[serde(untagged)]
-enum DirEntryNode {
-    File {
-        name: String,
-    },
-    Dir {
-        name: String,
-        children: Vec<DirEntryNode>,
-    },
-}
-
-fn traverse(path: &Path) -> Result<Vec<DirEntryNode>, ZagreusError> {
-    let files = std::fs::read_dir(path)?;
-    Ok(files
-        .filter_map(|entry| entry.ok())
-        .map(|entry| {
-            let child_path = entry.path();
-            let child_name = get_filename(entry)?;
-            match child_path.is_file() {
-                true => Ok(DirEntryNode::File { name: child_name }),
-                false => Ok(DirEntryNode::Dir {
-                    name: child_name,
-                    children: traverse(&child_path)?,
-                }),
-            }
-        })
-        .filter_map(|entry: Result<DirEntryNode, ZagreusError>| entry.ok())
-        .collect())
-}
-
-fn get_filename(entry: DirEntry) -> Result<String, ZagreusError> {
-    match entry.file_name().into_string() {
-        Ok(filename) => Ok(filename),
-        Err(_) => Err(ZagreusError::from(format!(
-            "Failed to process filename: {:?}",
-            entry.file_name()
-        ))),
     }
 }
 

--- a/zagreus-server/src/fs/mod.rs
+++ b/zagreus-server/src/fs/mod.rs
@@ -4,6 +4,7 @@ use crate::error::ZagreusError;
 
 #[cfg(test)]
 pub mod temp;
+pub mod util;
 pub mod zip;
 
 pub const TEMPLATES_DATA_SUBFOLDER_NAME: &str = "templates";

--- a/zagreus-server/src/fs/util.rs
+++ b/zagreus-server/src/fs/util.rs
@@ -1,0 +1,44 @@
+use crate::error::ZagreusError;
+use std::fs::DirEntry;
+use std::path::Path;
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum DirEntryNode {
+    File {
+        name: String,
+    },
+    Dir {
+        name: String,
+        children: Vec<DirEntryNode>,
+    },
+}
+
+pub fn traverse(path: &Path) -> Result<Vec<DirEntryNode>, ZagreusError> {
+    let files = std::fs::read_dir(path)?;
+    Ok(files
+        .filter_map(|entry| entry.ok())
+        .map(|entry| {
+            let child_path = entry.path();
+            let child_name = get_filename(entry)?;
+            match child_path.is_file() {
+                true => Ok(DirEntryNode::File { name: child_name }),
+                false => Ok(DirEntryNode::Dir {
+                    name: child_name,
+                    children: traverse(&child_path)?,
+                }),
+            }
+        })
+        .filter_map(|entry: Result<DirEntryNode, ZagreusError>| entry.ok())
+        .collect())
+}
+
+fn get_filename(entry: DirEntry) -> Result<String, ZagreusError> {
+    match entry.file_name().into_string() {
+        Ok(filename) => Ok(filename),
+        Err(_) => Err(ZagreusError::from(format!(
+            "Failed to process filename: {:?}",
+            entry.file_name()
+        ))),
+    }
+}

--- a/zagreus-swagger-docs/spec.yaml
+++ b/zagreus-swagger-docs/spec.yaml
@@ -56,7 +56,13 @@ paths:
       operationId: getAssets
       responses:
         '200':
-          $ref: '#/components/responses/200'
+          description: 'Assets returned successfully'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AssetResponse'
     post:
       description: Uploads the given asset to the specified template so that it can be used in the template.
       requestBody:
@@ -219,6 +225,17 @@ components:
   responses:
     '200':
       description: Operation succeeded
+  schemas:
+    AssetResponse:
+      description: "An asset described by its name and optionally child assets (if it's a folder)."
+      type: object
+      properties:
+        name:
+          type: string
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/AssetResponse'
 tags:
   - name: general
     description: General operations

--- a/zagreus-swagger-docs/spec.yaml
+++ b/zagreus-swagger-docs/spec.yaml
@@ -50,7 +50,7 @@ paths:
   '/api/template/{templateName}/asset':
     summary: Manage template assets
     get:
-      description: Returns the filenames for the currently uploaded assets for the template with the given name.
+      description: Returns a recursive list of the currently uploaded asset files for the template with the given name.
       tags:
         - template
       operationId: getAssets


### PR DESCRIPTION
## Motivation
Users may choose to organize their assets in subdirectories within the assets directory. In that case, the current implementation of the `GET .../asset` endpoint would only return the top level entries.

## Changes
* Replace file listing logic in `get_asset_filenames()` with custom directory traversal implementation
* Move traversal into a new `util` mod in `fs`
* Change response model to a nested list of `{ name, children? }` objects
* Adapt e2e test scenario and Swagger docs

## New Response Model
```json
[
   {
       "name": "anchor.png"
   },
   {
       "name": "images",
       "children": [
           {
               "name": "something.png"
           },
           {
               "name": "somethingElse.jpg"
           }
       ]
   },
   {
       "name": "animations.css"
   }
]