### PR TITLE
Enable strict mode in zagreus runtime

### DIFF
--- a/zagreus-runtime/src/error.ts
+++ b/zagreus-runtime/src/error.ts
@@ -49,7 +49,7 @@ const reportErrorOnSender = (
   const message: TaggedEnumType<ClientMessage, LogErrorPayload> = {
     tag: "LogError",
     payload: {
-      stack: error.stack,
+      stack: error.stack ?? "",
       message: error.message,
     },
   };

--- a/zagreus-runtime/src/manipulation/animation.ts
+++ b/zagreus-runtime/src/manipulation/animation.ts
@@ -88,6 +88,9 @@ export const getMaxTimeoutFromSequences = (sequences: string[]): number => {
   let maxTimeout = 0;
   sequences.forEach((sequenceName) => {
     const sequence = findAnimationSequence(sequenceName, state);
+    if (!sequence) {
+      return;
+    }
     const timeout = getMaxTimeoutFromSequence(sequence);
     maxTimeout = Math.max(maxTimeout, timeout);
   });

--- a/zagreus-runtime/src/runtime.ts
+++ b/zagreus-runtime/src/runtime.ts
@@ -60,15 +60,16 @@ if (!window.zagreus) {
     registerStateListener: registerStateListener,
     registerAnimations: registerAnimations,
     _internal: {
-      instance: undefined,
-      host: undefined,
-      port: undefined,
+      // Placeholders until setup() and installErrorHandler() populate them.
+      instance: "",
+      host: "",
+      port: "",
       secure: false,
       websocketSender: undefined,
       animationSequences: {},
       animationQueues: {},
       states: {},
-      errorReporter: undefined,
+      errorReporter: () => undefined,
     },
   };
 }

--- a/zagreus-runtime/src/setup.ts
+++ b/zagreus-runtime/src/setup.ts
@@ -66,12 +66,12 @@ export function registerAnimations(...animations: AnimationSequence[]) {
     .map((sequence) => ({
       ...sequence,
       steps: sequence.steps.map((step) => ({
-        start: 0,
         ...step,
+        start: step.start ?? 0,
         animations: step.animations.map((animation) => ({
-          direction: "normal",
-          iterations: 1,
           ...animation,
+          direction: animation.direction ?? "normal",
+          iterations: animation.iterations ?? 1,
         })),
       })),
     }))

--- a/zagreus-runtime/src/websocket/websocket-handler.ts
+++ b/zagreus-runtime/src/websocket/websocket-handler.ts
@@ -40,7 +40,6 @@ const templateMessageHandlers: EnumTypeHandler<ServerMessage, WebsocketSender> =
     SetState: (payload: SetStatePayload, sender) => {
       const internalState = getInternalZagreusState();
       // The server may send a null value; treat it as the empty state value,
-      // consistent with the default used when registering a state listener.
       const value = payload.value ?? "";
       if (!internalState.states[payload.name]) {
         internalState.states[payload.name] = {

--- a/zagreus-runtime/src/websocket/websocket-handler.ts
+++ b/zagreus-runtime/src/websocket/websocket-handler.ts
@@ -39,18 +39,21 @@ const templateMessageHandlers: EnumTypeHandler<ServerMessage, WebsocketSender> =
     },
     SetState: (payload: SetStatePayload, sender) => {
       const internalState = getInternalZagreusState();
+      // The server may send a null value; treat it as the empty state value,
+      // consistent with the default used when registering a state listener.
+      const value = payload.value ?? "";
       if (!internalState.states[payload.name]) {
         internalState.states[payload.name] = {
-          value: payload.value,
+          value,
           changedListeners: [],
         };
       } else {
-        internalState.states[payload.name].value = payload.value;
+        internalState.states[payload.name].value = value;
       }
       internalState.states[payload.name].changedListeners.forEach((listener) =>
-        listener(payload.value),
+        listener(value),
       );
-      sender.sendStateSetMessage(payload.name, payload.value);
+      sender.sendStateSetMessage(payload.name, value);
     },
   };
 

--- a/zagreus-runtime/tsconfig.json
+++ b/zagreus-runtime/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "outDir": "./dist/",
     "rootDir": "./src/",
-    "strict": false,
+    "strict": true,
     "noImplicitAny": true,
     "module": "ES6",
     "target": "ES2016",


### PR DESCRIPTION
TypeScript 7 makes `strict` true by default. In PR #190 (the v7 bump) `strict` was explicitly pinned back to `false` so the version bump stayed behavior-neutral and the build went green without touching runtime code. This follow-up turns `strict` on for the zagreus runtime and fixes the null-safety issues it surfaces, so the runtime benefits from the stricter checking going forward.

The changes are intentionally small and behavior-preserving. Each fix keeps the previous runtime behavior while satisfying `strictNullChecks`, so a reviewer can validate them one by one.

## Details

### Internal state placeholders

`_internal` was initialized with `undefined` for `instance`, `host`, `port` and `errorReporter`, which are declared as required. These are populated later by `setup()` and `installErrorHandler()` and are never read before then (the websocket connection only starts after `setup()`). They now use concrete placeholders (empty strings and a no-op reporter), consistent with the existing `secure: false` default.

### SetState null handling

The server sends `value` as `Option<&str>`, so `SetStatePayload.value` is optional and can arrive as null. The handler now normalizes a null value to the empty string before storing it and notifying listeners. This matches the empty-string default already used in `registerStateListener` and keeps `StateVariable.value` and `StateChangeListener` as non-null `string`. Note this is a small behavior change for the null case: a null value is now stored and echoed as `""` instead of `undefined`.

### Animation defaults

`registerAnimations` filled defaults with `{ start: 0, ...step }` and `{ direction: "normal", iterations: 1, ...animation }`. Because the step and animation types declare those fields as required, strict mode flags the leading defaults as always overwritten. The defaults are applied after the spread with `??` instead, so they still fill missing runtime values without the duplicate-property warning.

### Smaller fixes

A missing `Error.stack` now defaults to an empty string when reporting errors, and `getMaxTimeoutFromSequences` skips sequence names that cannot be found instead of passing `undefined` on.
